### PR TITLE
Fixed a deprecated method call(render_text)

### DIFF
--- a/t/auth.t
+++ b/t/auth.t
@@ -20,7 +20,7 @@ plugin 'params_auth';
 get '/' => sub {
     my $self = shift;
 
-    return $self->render_text('ok')
+    return $self->render(text => 'ok')
       if $self->params_auth(
               userinput => passinput =>
                 sub { return 1 if "@_" eq 'username password' }


### PR DESCRIPTION
The "successfull" branch of the authchecking in Line 23 called $self->render_text(...) which was deprecated in a previous Mojolicious version.
