### PR TITLE
Update required Mojolicious version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,4 +16,4 @@ repository.url   = git://github.com/tempire/mojolicious-plugin-paramsauth.git
 repository.type  = git
 
 [Prereqs]
-Mojolicious = 1.41
+Mojolicious = 5.0

--- a/t/auth.t
+++ b/t/auth.t
@@ -5,7 +5,7 @@ use Mojo::Parameters;
 
 # Make sure sockets are working
 plan skip_all => 'working sockets required for this test!'
-  unless Mojo::IOLoop->new->generate_port;    # Test server
+  unless Mojo::IOLoop->new->server->generate_port;    # Test server
 
 plan tests => 14;
 


### PR DESCRIPTION
As generate_port was moved from Mojo::IOLoop to Mojo::IOLoop::Server in Mojolicious 5.0, the minimum required version is 5.0
