### PR TITLE
Fix missing method generate_port()

### DIFF
--- a/lib/Mojolicious/Plugin/ParamsAuth.pm
+++ b/lib/Mojolicious/Plugin/ParamsAuth.pm
@@ -63,7 +63,7 @@ L<Mojolicous::Plugin::ParamsAuth> is a helper for authenticating using url param
     get '/' => sub {
         my $self = shift;
 
-        return $self->render_text('ok')
+        return $self->render(text => 'ok')
           if $self->params_auth(userinput => passinput =>
               sub { return 1 if "@_" eq 'username password' });
     };

--- a/t/auth.t
+++ b/t/auth.t
@@ -5,7 +5,7 @@ use Mojo::Parameters;
 
 # Make sure sockets are working
 plan skip_all => 'working sockets required for this test!'
-  unless Mojo::IOLoop->new->generate_port;    # Test server
+  unless Mojo::IOLoop::Server->generate_port;    # Test server
 
 plan tests => 14;
 


### PR DESCRIPTION
Fix for error:

  Can't locate object method "generate_port" via package "Mojo::IOLoop"
at t/auth.t line 7.

Also replaced render_text() in usage example.
